### PR TITLE
Add github actions tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,89 @@
+name: Run pg_anonymize tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  DATADIR: /dev/shm/data
+  LOGFILE: /dev/shm/data/logfile
+
+jobs:
+  pg_anonymize_tests:
+    name: pg_anonymize tests
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        postgres_major_version: [
+          "11",
+          "12",
+          "13",
+          "14",
+          "15"
+        ]
+        os: ["ubuntu-22.04"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up prerequisites and environment
+      run: |
+        echo "************ CLEAN IMAGE ***********"
+        sudo apt remove -y '^postgres.*' '^libpq.*'
+        echo ""
+
+        echo "********* REPOSITORY SET UP ********"
+        sudo apt-get install -y wget gnupg
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo apt-get update -y -qq --fix-missing
+        echo ""
+
+        echo "*********** ENVIRONMENT ************"
+        export PG_MAJOR_VERSION=${{ matrix.postgres_major_version }}
+        echo "PG_MAJOR_VERSION=$PG_MAJOR_VERSION" >> $GITHUB_ENV
+        echo "MAKEFLAGS=$MAKEFLAGS -j $(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+        echo ""
+
+        echo "******** INSTALL POSTGRES **********"
+        sudo apt-get install -y \
+          postgresql-$PG_MAJOR_VERSION \
+          postgresql-server-dev-$PG_MAJOR_VERSION
+        echo ""
+
+        echo "******* INSTALL DEPENDENCIES *******"
+        sudo apt-get install -y \
+          gcc \
+          make \
+          build-essential \
+          pkg-config
+        echo ""
+
+        echo "********** READJUST PATH ***********"
+        export PATH=$(pg_config --bindir):$PATH
+        echo "PATH=$PATH" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+        echo ""
+
+    - name: Start a postgres ${{ matrix.postgres_major_version }} server
+      run: |
+        sudo chmod a+rwx /var/run/postgresql/
+        pg_ctl -D $DATADIR initdb
+        pg_ctl -D $DATADIR -l $LOGFILE start || cat $LOGFILE
+        psql -c 'select 1 as ok' postgres
+
+    - name: Build and install pg_anonymize for posgres ${{ matrix.postgres_major_version }}
+      run: |
+        make
+        sudo make install
+
+    - name: Run pg_anonymize tests for postgres ${{ matrix.postgres_major_version }}
+      run: make installcheck || ( errcode=$?; cat regression.diffs && exit $errcode )
+
+    - name: Stop the running postgres ${{ matrix.postgres_major_version }} server
+      run: pg_ctl -D $DATADIR stop


### PR DESCRIPTION
This is a basic setup for a CI based on github actions. It is currently executed only on main and PRs against it. It is run against postgres major versions [11-15] on an ubuntu 22.04.

It is a bit rough yet it works and is a decent base for extending in a later stage.