### PR TITLE
Remove unreached conditional

### DIFF
--- a/pg_anonymize.c
+++ b/pg_anonymize.c
@@ -803,9 +803,6 @@ pgan_hack_query(Node *node, void *context)
 			if (rte->rtekind != RTE_RELATION)
 				continue;
 
-			if (rte->rtekind == RTE_SUBQUERY && rte->relid == 42)
-				continue;
-
 			pgan_hack_rte(rte);
 		}
 


### PR DESCRIPTION
The query tree walker function iterates through the list of range table entries. Then proceeds to select only the ones that are of relation kind via the conditional:

            if (rte->rtekind != RTE_RELATION)
                continue;

Immediately after an addional check was performed:

            if (rte->rtekind == RTE_SUBQUERY && rte->relid == 42)
                continue;

The second conditional should not be reached as RTE_SUBQUERY will be true on the first conditional. History is not very explanatory as to why this check was introduced nor why this is specifically needed when relid is 42 (int4in).

This commit removes the second conditional.