### PR TITLE
Fix show shared_preload_libraries

### DIFF
--- a/pg_anonymize.c
+++ b/pg_anonymize.c
@@ -412,10 +412,14 @@ pgan_check_preload_lib(char *libnames, char *kind, bool missing_ok)
 {
 		List	   *xpl;
 		ListCell   *lc;
+		char	   *rawstring;
 		char	   *libname;
 		int			nb;
 
-		if (!SplitIdentifierString(libnames, ',', &xpl))
+		/* Need a modifiable copy of string */
+		rawstring = pstrdup(libnames);
+
+		if (!SplitIdentifierString(rawstring, ',', &xpl))
 			elog(ERROR, "Could not parse %s", kind);
 
 		if (!missing_ok)


### PR DESCRIPTION
If add the extension to `shared_preload_libraries`, guc will show only 1st extension in list

Let's `postgresql.conf` contains `pg_anonymize`
```sql
shared_preload_libraries = 'auto_explain,pg_stat_statements,pg_anonymize'
```

In postgres let's show `shared_preload_libraries`. Shown only 1st extension.

```sql
select name, setting from pg_settings where name = 'shared_preload_libraries';

name           |             setting             
--------------------------+---------------------------------
 shared_preload_libraries | auto_explain
(1 row)
```

If we remove `pg_anonymize` all extensions are shown
```sql
name           |             setting             
--------------------------+---------------------------------
 shared_preload_libraries | auto_explain,pg_stat_statements
(1 row)
```


